### PR TITLE
chore(deps): bump @lagoon-protocol/v0-core to 0.19.10, v0-viem to 0.18.7

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,8 +4,8 @@
     "": {
       "name": "tmp",
       "dependencies": {
-        "@lagoon-protocol/v0-core": "^0.19.7",
-        "@lagoon-protocol/v0-viem": "^0.18.4",
+        "@lagoon-protocol/v0-core": "^0.19.10",
+        "@lagoon-protocol/v0-viem": "^0.18.7",
         "viem": "^2.37.9",
       },
       "devDependencies": {
@@ -19,9 +19,9 @@
   "packages": {
     "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.0", "", {}, "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg=="],
 
-    "@lagoon-protocol/v0-core": ["@lagoon-protocol/v0-core@0.19.7", "", { "peerDependencies": { "typescript": "^5.9.3" } }, "sha512-M37fVO3xO33zVHR/uZjrrgDoZM41yYbKKd8JbYttuGZ44yuSs48L5tkSQNFcjLH8Ph6etinGFVzKU/h0aUi3/A=="],
+    "@lagoon-protocol/v0-core": ["@lagoon-protocol/v0-core@0.19.10", "", { "peerDependencies": { "typescript": "^5.9.3" } }, "sha512-8vnelyTYQsBcgPVxJfxY9FuVj/phXfczpPV7AGOMikIOg5ZMhM+qJKPyK6SefpHIkO2kOrl0LZgDfmBp8ICOUQ=="],
 
-    "@lagoon-protocol/v0-viem": ["@lagoon-protocol/v0-viem@0.18.4", "", { "peerDependencies": { "@lagoon-protocol/v0-core": "^0.19.6", "viem": "^2.0.0" } }, "sha512-t2tGhbUyQ28uGnD+xbkVhfdouEKf9wkiZZASLOSlCOczyHcZuqfJv5ewMQHxd7vX3aUckiO+ljMqPeV+cd7Rgg=="],
+    "@lagoon-protocol/v0-viem": ["@lagoon-protocol/v0-viem@0.18.7", "", { "peerDependencies": { "@lagoon-protocol/v0-core": "^0.19.6", "viem": "^2.0.0" } }, "sha512-1vevrq1liWRSz/LQ5wAIaq928NfARBwOWKwOeBTYvAe/yLIAt+h1TDFccNReJB4UU1lK7R6u0Wdcs+hZfRfxjw=="],
 
     "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@lagoon-protocol/v0-core": "^0.19.7",
-    "@lagoon-protocol/v0-viem": "^0.18.4",
+    "@lagoon-protocol/v0-core": "^0.19.10",
+    "@lagoon-protocol/v0-viem": "^0.18.7",
     "viem": "^2.37.9"
   }
 }


### PR DESCRIPTION
## Summary
Picks up the corrected v0.6.0 vault implementation addresses for Ethereum, Arbitrum, Base, and Avalanche (shipped in [sdk-v0#78](https://github.com/hopperlabsxyz/sdk-v0/pull/78)). The previously-pinned `^0.19.7` of `@lagoon-protocol/v0-core` resolved to addresses that no longer point at the live v0.6.0 contracts on those chains.

| Chain | v0.6.0 address (new) |
|---|---|
| Ethereum  | `0x70274C69Ef1fA492506394D982391c6f3008e785` |
| Arbitrum  | `0xE0eDaAcF50Ec49aEe917b0ef6b1615ECdccaF64D` |
| Base      | `0x49c6690a9e909a0d23F20DB416706EBc069B3DC7` |
| Avalanche | `0x1e17e7848b2F56F75b16550471F455071a9F955f` |

Dep ranges bumped: `v0-core ^0.19.7 → ^0.19.10`, `v0-viem ^0.18.4 → ^0.18.7`. `bun.lock` refreshed.

## Test plan
- [x] `bun install` clean
- [x] `bunx tsc --noEmit` — no *new* errors introduced; two pre-existing errors in `src/client.ts:97,101` (missing `MonadMainnet`/`SeiMainnet`/`HemiMainnet` entries in `chains` map) are unchanged from main
- [ ] `./deploy.ts` simulation against a v0.6.0 config on mainnet/arbitrum/base/avalanche — confirm the resolved logic address matches the new value above (will revert at the bytes-overload selector check until the v3 factory ships, as documented in CLAUDE.md)