### PR TITLE
feat(v0.6): force externalSanctionsList to address(0)

### DIFF
--- a/config.jsonc
+++ b/config.jsonc
@@ -55,10 +55,6 @@
       // v0.6 only. Security council address — emergency pause powers.
       // Set to 0x0…0 to disable.
       "securityCouncil": "0x1a90000000000000000000000000000000000000",
-      // v0.6 only. External sanctions list contract (OFAC-like oracle).
-      // Chainalysis default on Ethereum: 0x40C57923924B5c5c5455c48D93317139ADDaC8fb
-      // Set to 0x0…0 if you don't want to consult one.
-      "externalSanctionsList": "0x0000000000000000000000000000000000000000",
       // v0.6 only. Initial totalAssets (uint256). Use 0 for fresh vaults;
       // non-zero is meant for migrations that carry an existing balance.
       "initialTotalAssets": 0,

--- a/config.ts
+++ b/config.ts
@@ -62,10 +62,6 @@ export const config: Config = {
       // v0.6 only. Security council address — emergency pause powers.
       // Set to 0x0…0 to disable.
       securityCouncil: ROLE,
-      // v0.6 only. External sanctions list contract (OFAC-like oracle).
-      // Chainalysis default on Ethereum: 0x40C57923924B5c5c5455c48D93317139ADDaC8fb
-      // Set to 0x0…0 if you don't want to consult one.
-      externalSanctionsList: ZERO,
       // v0.6 only. Initial totalAssets (uint256). Use 0 for fresh vaults;
       // non-zero is meant for migrations that carry an existing balance.
       initialTotalAssets: 0,

--- a/deploy.ts
+++ b/deploy.ts
@@ -184,6 +184,14 @@ async function main() {
 
     for (const vaultConfig of vaultsToDeploy) {
       if (!vaultConfig) continue;
+      if (
+        vaultConfig.version === "v0.6.0" &&
+        "externalSanctionsList" in (vaultConfig as Record<string, unknown>)
+      ) {
+        console.warn(
+          `[warn] vault "${vaultConfig.name}": externalSanctionsList is set in config but will be ignored — the deployer forces address(0).`
+        );
+      }
       const res = await deploy({ vaultConfig, chainId, simulate });
       printResult(chainId, res, simulate);
     }

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -108,6 +108,7 @@ function encodeInitV6(cfg: VaultConfigV6): Hex {
       exitRate: cfg.exitRate,
       haircutRate: cfg.haircutRate,
       securityCouncil: cfg.securityCouncil,
+      // Forced to address(0) — the deployer never enrolls a sanctions oracle.
       externalSanctionsList: "0x0000000000000000000000000000000000000000",
       initialTotalAssets: BigInt(cfg.initialTotalAssets),
       superOperator: cfg.superOperator,

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -108,7 +108,7 @@ function encodeInitV6(cfg: VaultConfigV6): Hex {
       exitRate: cfg.exitRate,
       haircutRate: cfg.haircutRate,
       securityCouncil: cfg.securityCouncil,
-      externalSanctionsList: cfg.externalSanctionsList,
+      externalSanctionsList: "0x0000000000000000000000000000000000000000",
       initialTotalAssets: BigInt(cfg.initialTotalAssets),
       superOperator: cfg.superOperator,
       allowHighWaterMarkReset: cfg.allowHighWaterMarkReset,

--- a/src/type.ts
+++ b/src/type.ts
@@ -32,7 +32,6 @@ export type VaultConfigV6 = BaseVaultConfig & {
   exitRate: number;
   haircutRate: number;
   securityCouncil: Address;
-  externalSanctionsList: Address;
   initialTotalAssets: number | string;
   superOperator: Address;
   allowHighWaterMarkReset: boolean;


### PR DESCRIPTION
## Summary
Drops `externalSanctionsList` from the user-facing v0.6 vault config and hardcodes it to `address(0)` at encode time, so deployments cannot opt into a sanctions oracle through the config.

Files touched:
- [src/type.ts](src/type.ts) — remove `externalSanctionsList: Address` from `VaultConfigV6`
- [src/encoding.ts](src/encoding.ts) — hardcode `"0x000…000"` in `encodeInitV6` (the slot in `INIT_STRUCT_V6` stays — must match the on-chain ABI)
- [config.ts](config.ts) / [config.jsonc](config.jsonc) — remove the field and its inline docs

## Test plan
- [x] `bunx tsc --noEmit` — no new errors. Two pre-existing errors in `src/client.ts:97,101` (missing `MonadMainnet`/`SeiMainnet`/`HemiMainnet` entries) are unchanged from main.
- [x] `./config.ts | jq '.vaultsToDeploy[0].externalSanctionsList'` — field is absent
- [ ] `./deploy.ts` simulation — the encoded init call should contain the zero address at the `externalSanctionsList` slot of the v0.6 InitStruct regardless of any leftover values in `config.jsonc`