### PR TITLE
chore(deps): bump @lagoon-protocol/v0-core to 0.19.11, v0-viem to 0.18.8

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,8 +4,8 @@
     "": {
       "name": "tmp",
       "dependencies": {
-        "@lagoon-protocol/v0-core": "^0.19.10",
-        "@lagoon-protocol/v0-viem": "^0.18.7",
+        "@lagoon-protocol/v0-core": "^0.19.11",
+        "@lagoon-protocol/v0-viem": "^0.18.8",
         "viem": "^2.37.9",
       },
       "devDependencies": {
@@ -19,9 +19,9 @@
   "packages": {
     "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.0", "", {}, "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg=="],
 
-    "@lagoon-protocol/v0-core": ["@lagoon-protocol/v0-core@0.19.10", "", { "peerDependencies": { "typescript": "^5.9.3" } }, "sha512-8vnelyTYQsBcgPVxJfxY9FuVj/phXfczpPV7AGOMikIOg5ZMhM+qJKPyK6SefpHIkO2kOrl0LZgDfmBp8ICOUQ=="],
+    "@lagoon-protocol/v0-core": ["@lagoon-protocol/v0-core@0.19.11", "", { "peerDependencies": { "typescript": "^5.9.3" } }, "sha512-iRx2s4TGhQ4amy12N1jCFuKQ3Jiv9HfbG5vThW3zg8C3RKJQPvVi0uiP9CZRj5+duWeCn+KZ21u8qw4Z5QjXlQ=="],
 
-    "@lagoon-protocol/v0-viem": ["@lagoon-protocol/v0-viem@0.18.7", "", { "peerDependencies": { "@lagoon-protocol/v0-core": "^0.19.6", "viem": "^2.0.0" } }, "sha512-1vevrq1liWRSz/LQ5wAIaq928NfARBwOWKwOeBTYvAe/yLIAt+h1TDFccNReJB4UU1lK7R6u0Wdcs+hZfRfxjw=="],
+    "@lagoon-protocol/v0-viem": ["@lagoon-protocol/v0-viem@0.18.8", "", { "peerDependencies": { "@lagoon-protocol/v0-core": "^0.19.6", "viem": "^2.0.0" } }, "sha512-NmD+G4u89KBw+MnmZMglQx2c7sv0O+97Vzkun2iakf8eUYvm5q7vUWYoAeKzISkplHNoVy4odJeA38JGCqwssQ=="],
 
     "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@lagoon-protocol/v0-core": "^0.19.10",
-    "@lagoon-protocol/v0-viem": "^0.18.7",
+    "@lagoon-protocol/v0-core": "^0.19.11",
+    "@lagoon-protocol/v0-viem": "^0.18.8",
     "viem": "^2.37.9"
   }
 }


### PR DESCRIPTION
## Summary

- Bumps `@lagoon-protocol/v0-core` from `^0.19.10` → `^0.19.11`
- Bumps `@lagoon-protocol/v0-viem` from `^0.18.7` → `^0.18.8`
- Both are the latest patch releases on npm (published 2026-05-15)
- Peer deps remain compatible — `v0-viem@0.18.8` still requires `v0-core` `^0.19.6`

No source changes; only `package.json` and `bun.lock`.

## Test plan

- [x] `bun install` resolves to `@lagoon-protocol/v0-core@0.19.11` and `@lagoon-protocol/v0-viem@0.18.8`
- [x] `bunx tsc --noEmit` produces no new errors versus baseline (the two pre-existing `src/client.ts` `TS7053` errors around `ChainId.MonadMainnet` are unchanged and were already present on `main`)
- [ ] Smoke-test simulate (`./config.ts > config.jsonc && ./deploy.ts`) — expected to revert against the current v2 factory per [CLAUDE.md](CLAUDE.md), which is unchanged by this bump