### PR TITLE
feat(chains): add Monad, Sei, Hemi, Rayls support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,9 +4,9 @@
     "": {
       "name": "tmp",
       "dependencies": {
-        "@lagoon-protocol/v0-core": "^0.19.11",
-        "@lagoon-protocol/v0-viem": "^0.18.8",
-        "viem": "^2.37.9",
+        "@lagoon-protocol/v0-core": "^0.19.15",
+        "@lagoon-protocol/v0-viem": "^0.18.10",
+        "viem": "^2.50.4",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -19,9 +19,9 @@
   "packages": {
     "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.0", "", {}, "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg=="],
 
-    "@lagoon-protocol/v0-core": ["@lagoon-protocol/v0-core@0.19.11", "", { "peerDependencies": { "typescript": "^5.9.3" } }, "sha512-iRx2s4TGhQ4amy12N1jCFuKQ3Jiv9HfbG5vThW3zg8C3RKJQPvVi0uiP9CZRj5+duWeCn+KZ21u8qw4Z5QjXlQ=="],
+    "@lagoon-protocol/v0-core": ["@lagoon-protocol/v0-core@0.19.15", "", { "peerDependencies": { "typescript": "^5.9.3" } }, "sha512-HImf7T/EzYgc3OliwLZKIy+KN4Vsy2D0gi+pv7k93o0NDr0I7Vzph4rKHavPa/Evi/opGGeAbOzrpweq0dDS5g=="],
 
-    "@lagoon-protocol/v0-viem": ["@lagoon-protocol/v0-viem@0.18.8", "", { "peerDependencies": { "@lagoon-protocol/v0-core": "^0.19.6", "viem": "^2.0.0" } }, "sha512-NmD+G4u89KBw+MnmZMglQx2c7sv0O+97Vzkun2iakf8eUYvm5q7vUWYoAeKzISkplHNoVy4odJeA38JGCqwssQ=="],
+    "@lagoon-protocol/v0-viem": ["@lagoon-protocol/v0-viem@0.18.10", "", { "peerDependencies": { "@lagoon-protocol/v0-core": "^0.19.6", "viem": "^2.0.0" } }, "sha512-wlWpw63MEl8e9f0eyeyQ6NatTsc1C8axQYwcDRVR10tf5/sqDiKh/1tyTuhp/M4ib9SGo9ZfVoMeoba3nsoIXw=="],
 
     "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 
@@ -41,7 +41,7 @@
 
     "@types/react": ["@types/react@19.1.9", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA=="],
 
-    "abitype": ["abitype@1.1.0", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-6Vh4HcRxNMLA0puzPjM5GBgT4aAcFGKZzSgAXvuZ27shJP6NEpielTuqbBmZILR5/xd0PizkBGy5hReKz9jl5A=="],
+    "abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
 
     "bun-types": ["bun-types@1.2.19", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-uAOTaZSPuYsWIXRpj7o56Let0g/wjihKCkeRqUBhlLVM/Bt+Fj9xTo+LhC1OV1XDaGkz4hNC80et5xgy+9KTHQ=="],
 
@@ -51,15 +51,15 @@
 
     "isows": ["isows@1.0.7", "", { "peerDependencies": { "ws": "*" } }, "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg=="],
 
-    "ox": ["ox@0.9.6", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.0.9", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-8SuCbHPvv2eZLYXrNmC0EC12rdzXQLdhnOMlHDW2wiCPLxBrOOJwX5L5E61by+UjTPOryqQiRSnjIKCI+GykKg=="],
+    "ox": ["ox@0.14.22", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.2.3", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-nb5msL8qWbPglhIfZbGJAfw3cqiJjFMiWmACt7kgyWtLib12tcctbHufMT9Hb0Lr6Pt4k9I3dbpueTpbhvbqvA=="],
 
     "typescript": ["typescript@5.9.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="],
 
     "undici-types": ["undici-types@7.10.0", "", {}, "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag=="],
 
-    "viem": ["viem@2.37.9", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.1.0", "isows": "1.0.7", "ox": "0.9.6", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-XXUOE5yJcjr9/M9kRoQcPMUfetwHprO9aTho6vNELjBKJIBx7rYq1fjvBw+xEnhsRjhh5lsORi6B0h8fYFB7NA=="],
+    "viem": ["viem@2.50.4", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.14.22", "ws": "8.20.1" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-rf98F4s3Vlb+uJZEKfay3IbBw3CNCbVtx5Y3UIljlO2tSX420g/J0WQSYsjzBSasUFgxgsXabji14O9kGbiqgg=="],
 
-    "ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
+    "ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
 
     "@scure/bip32/@noble/curves": ["@noble/curves@1.9.2", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-HxngEd2XUcg9xi20JkwlLCtYwfoFw4JGkuZpT+WlsPD4gB/cxkvTD8fSsoAnphGZhFdZYKeQIPCuFlWPm1uE0g=="],
   }

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@lagoon-protocol/v0-core": "^0.19.11",
-    "@lagoon-protocol/v0-viem": "^0.18.8",
-    "viem": "^2.37.9"
+    "@lagoon-protocol/v0-core": "^0.19.15",
+    "@lagoon-protocol/v0-viem": "^0.18.10",
+    "viem": "^2.50.4"
   }
 }

--- a/src/addresses.ts
+++ b/src/addresses.ts
@@ -34,13 +34,14 @@ export function getImplementationAddress(
   if (!entry)
     throw new Error(`Chain ${chainId} has no known Lagoon implementations`);
 
+  const versionAddrs = entry as unknown as Record<string, string | undefined>;
   const key = VERSION_KEY[version];
-  const addr = (entry as Record<string, string | undefined>)[key];
+  const addr = versionAddrs[key];
 
   if (!addr || addr.toLowerCase() === ZERO_ADDRESS) {
     const available = (Object.keys(VERSION_KEY) as LagoonVersion[]).filter(
       (v) => {
-        const a = (entry as Record<string, string | undefined>)[VERSION_KEY[v]];
+        const a = versionAddrs[VERSION_KEY[v]];
         return a && a.toLowerCase() !== ZERO_ADDRESS;
       }
     );

--- a/src/client.ts
+++ b/src/client.ts
@@ -23,6 +23,9 @@ import {
   mantle,
   bsc,
   plasma,
+  monad,
+  sei,
+  hemi,
 } from "viem/chains";
 import { loadAccount } from "./utils";
 
@@ -37,6 +40,20 @@ const hyperevm = defineChain({
     },
     public: {
       http: ["https://hyperliquid.drpc.org"],
+    },
+  },
+});
+
+// Rayls is not yet defined in viem/chains.
+const rayls = defineChain({
+  ...ChainUtils.CHAIN_METADATA[ChainId.RaylsMainnet],
+  network: "rayls",
+  rpcUrls: {
+    default: {
+      http: ["https://mainnet-rpc.rayls.com"],
+    },
+    public: {
+      http: ["https://mainnet-rpc.rayls.com"],
     },
   },
 });
@@ -59,6 +76,10 @@ export const chains = {
   [ChainId.HyperEVMMainnet]: hyperevm,
   [ChainId.LineaMainnet]: linea,
   [ChainId.PlasmaMainnet]: plasma,
+  [ChainId.MonadMainnet]: monad,
+  [ChainId.SeiMainnet]: sei,
+  [ChainId.HemiMainnet]: hemi,
+  [ChainId.RaylsMainnet]: rayls,
 };
 
 // Alchemy subdomain per chain, for chains Alchemy supports.


### PR DESCRIPTION
## Summary
- Bump `@lagoon-protocol/v0-core` `0.19.11 → 0.19.15`, `@lagoon-protocol/v0-viem` `0.18.8 → 0.18.10`, and `viem` `2.37.9 → 2.50.4`.
- Register the four `ChainId` members that were missing from the chain map: **Monad** (143), **Sei** (1329), **Hemi** (43111), **Rayls** (72957). All four have `optinFactory` entries in the SDK `addresses` map, so deploys to them are now supported.
- The viem bump exposes `monad`/`sei`/`hemi` in `viem/chains`. Rayls is not yet in viem, so it is defined inline via `ChainUtils.CHAIN_METADATA[RaylsMainnet]` + its public RPC (`https://mainnet-rpc.rayls.com`), mirroring the existing HyperEVM pattern.
- Registering all 21 `ChainId` members also clears the long-standing `TS7053` index error in `createChainClients` (previously surfaced as `ChainId.MonadMainnet`).
- `v0-core` 0.19.15 adds an `isOptinFactoryV3` boolean to chain address entries; the entry cast in `addresses.ts` is routed through `unknown` to stay valid.

Note: the new chains are intentionally left out of `ALCHEMY_SUBDOMAIN` (consistent with Tac/Katana/HyperEVM/Plasma) — they fall back to viem's default public RPC (inline RPC for Rayls), overridable via `RPC_URL_<chainId>` in `.env`.

## Test plan
- [x] `bunx tsc --noEmit` passes cleanly (the only project check)
- [ ] Simulate a deploy against one of the new chains (e.g. Sei or Hemi) once a target config is available